### PR TITLE
held fees unlocked by timestamp. feeless moved.

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@ evm_version = 'paris'                   # Required for L2s (Optimism, Arbitrum, 
 match_contract = "_Local"               # Do not run fork tests
 sizes = true
 verbosity = 3                           # display errors
-optimizer_runs = 300
+optimizer_runs = 200
 block_number = 14126430
 block_timestamp = 1643802347
 

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -11,6 +11,7 @@ import "../src/JBRulesets.sol";
 import "../src/JBDirectory.sol";
 import "../src/JBTokens.sol";
 import "../src/JBSplits.sol";
+import "../src/JBFeelessAddresses.sol";
 import "../src/JBFundAccessLimits.sol";
 import "../src/JBController.sol";
 import "../src/JBTerminalStore.sol";
@@ -26,6 +27,7 @@ contract Deploy is Script {
     JBRulesets _rulesets;
     JBTokens _tokens;
     JBSplits _splits;
+    JBFeelessAddresses _feelessAddresses;
     JBFundAccessLimits _fundAccessLimits;
     JBController _controller;
     JBTerminalStore _terminalStore;
@@ -41,6 +43,7 @@ contract Deploy is Script {
         _permissions = new JBPermissions();
         _projects = new JBProjects(_manager);
         _prices = new JBPrices(_permissions, _projects, _manager);
+        _feelessAddresses = new JBFeelessAddresses(_manager);
         _directory = new JBDirectory(_permissions, _projects, msg.sender);
         _splits = new JBSplits(_directory);
         _fundAccessLimits = new JBFundAccessLimits(_directory);
@@ -53,7 +56,7 @@ contract Deploy is Script {
         _directory.setIsAllowedToSetFirstController(address(_controller), true);
         _directory.transferOwnership(_manager);
         _multiTerminal = new JBMultiTerminal(
-            _permissions, _projects, _directory, _splits, _terminalStore, _PERMIT2, _trustedForwarder, _manager
+            _permissions, _projects, _directory, _splits, _terminalStore, _feelessAddresses, _PERMIT2, _trustedForwarder
         );
     }
 

--- a/src/JBFeelessAddresses.sol
+++ b/src/JBFeelessAddresses.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IJBFeelessAddresses} from "./interfaces/IJBFeelessAddresses.sol";
+
+/// @notice Stores and manages addresses that shouldn't incur fees when being paid towards or from.
+contract JBFeelessAddresses is Ownable, ERC165, IJBFeelessAddresses {
+    //*********************************************************************//
+    // --------------------- public stored properties -------------------- //
+    //*********************************************************************//
+
+    /// @notice Feeless addresses for this terminal.
+    /// @dev Feeless addresses can receive payouts without incurring a fee.
+    /// @dev Feeless addresses can use the surplus allowance without incurring a fee.
+    /// @dev Feeless addresses can be the beneficary of redemptions without incurring a fee.
+    /// @custom:param addr The address that may or may not be feeless.
+    mapping(address addr => bool) public override isFeelessAddress;
+
+    //*********************************************************************//
+    // -------------------------- public views --------------------------- //
+    //*********************************************************************//
+
+    /// @notice Indicates if this contract adheres to the specified interface.
+    /// @dev See {IERC165-supportsInterface}.
+    /// @param interfaceId The ID of the interface to check for adherance to.
+    /// @return A flag indicating if the provided interface ID is supported.
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IJBFeelessAddresses).interfaceId || interfaceId == type(IERC165).interfaceId;
+    }
+
+    /// @param owner The address that will own this contract.
+    constructor(address owner) Ownable(owner) {}
+
+    //*********************************************************************//
+    // ---------------------- external transactions ---------------------- //
+    //*********************************************************************//
+
+    /// @notice Sets an address as feeless or not feeless for this terminal.
+    /// @dev Only the owner of this contract can set addresses as feeless or not feeless.
+    /// @dev Feeless addresses can receive payouts without incurring a fee.
+    /// @dev Feeless addresses can use the surplus allowance without incurring a fee.
+    /// @dev Feeless addresses can be the beneficary of redemptions without incurring a fee.
+    /// @param addr The address to make feeless or not feeless.
+    /// @param flag A flag indicating whether the `address` should be made feeless or not feeless.
+    function setFeelessAddress(address addr, bool flag) external virtual override onlyOwner {
+        // Set the flag value.
+        isFeelessAddress[addr] = flag;
+
+        emit SetFeelessAddress(addr, flag, _msgSender());
+    }
+}

--- a/src/JBFeelessAddresses.sol
+++ b/src/JBFeelessAddresses.sol
@@ -17,7 +17,7 @@ contract JBFeelessAddresses is Ownable, ERC165, IJBFeelessAddresses {
     /// @dev Feeless addresses can use the surplus allowance without incurring a fee.
     /// @dev Feeless addresses can be the beneficary of redemptions without incurring a fee.
     /// @custom:param addr The address that may or may not be feeless.
-    mapping(address addr => bool) public override isFeelessAddress;
+    mapping(address addr => bool) public override isFeeless;
 
     //*********************************************************************//
     // -------------------------- public views --------------------------- //
@@ -47,7 +47,7 @@ contract JBFeelessAddresses is Ownable, ERC165, IJBFeelessAddresses {
     /// @param flag A flag indicating whether the `address` should be made feeless or not feeless.
     function setFeelessAddress(address addr, bool flag) external virtual override onlyOwner {
         // Set the flag value.
-        isFeelessAddress[addr] = flag;
+        isFeeless[addr] = flag;
 
         emit SetFeelessAddress(addr, flag, _msgSender());
     }

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -1567,9 +1567,6 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
         // Delete the held fees.
         delete _heldFeesOf[projectId][token];
 
-        // Keep a reference to the amount.
-        uint256 amount;
-
         // Keep a reference to the number of held fees.
         uint256 numberOfHeldFees = heldFees.length;
 
@@ -1590,9 +1587,6 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
                 _heldFeesOf[projectId][token].push(heldFee);
                 continue;
             }
-
-            // Get the fee amount.
-            amount = JBFees.feeAmountIn(heldFee.amount, FEE);
 
             // Process the fee.
             _processFee({

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -688,7 +688,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
         if (split.hook != IJBSplitHook(address(0))) {
             // This payout is eligible for a fee since the funds are leaving this contract and the split hook isn't a
             // feeless address.
-            if (!FEELESS_ADDRESSES.isFeelessAddress(address(split.hook))) {
+            if (!FEELESS_ADDRESSES.isFeeless(address(split.hook))) {
                 netPayoutAmount -= JBFees.feeAmountIn(amount, FEE);
             }
 
@@ -726,7 +726,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
 
             // This payout is eligible for a fee if the funds are leaving this contract and the receiving terminal isn't
             // a feelss address.
-            if (terminal != this && !FEELESS_ADDRESSES.isFeelessAddress(address(terminal))) {
+            if (terminal != this && !FEELESS_ADDRESSES.isFeeless(address(terminal))) {
                 netPayoutAmount -= JBFees.feeAmountIn(amount, FEE);
             }
 
@@ -804,7 +804,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
 
             // This payout is eligible for a fee since the funds are leaving this contract and the recipient isn't a
             // feeless address.
-            if (!FEELESS_ADDRESSES.isFeelessAddress(recipient)) {
+            if (!FEELESS_ADDRESSES.isFeeless(recipient)) {
                 netPayoutAmount -= JBFees.feeAmountIn(amount, FEE);
             }
 
@@ -1069,8 +1069,8 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
 
             // Determine if a fee should be taken. Fees are not exercised if the redemption rate is at its max (100%),
             // if the beneficiary is feeless, or if the fee beneficiary doesn't accept the given token.
-            bool takesFee = !FEELESS_ADDRESSES.isFeelessAddress(beneficiary)
-                && ruleset.redemptionRate() != JBConstants.MAX_REDEMPTION_RATE;
+            bool takesFee =
+                !FEELESS_ADDRESSES.isFeeless(beneficiary) && ruleset.redemptionRate() != JBConstants.MAX_REDEMPTION_RATE;
 
             // The amount being reclaimed must be at least as much as was expected.
             if (reclaimAmount < minReturnedTokens) revert INADEQUATE_RECLAIM_AMOUNT();
@@ -1271,7 +1271,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
         // The net amount is the final amount withdrawn after the fee has been taken.
         netAmountPaidOut = amountPaidOut
             - (
-                FEELESS_ADDRESSES.isFeelessAddress(_msgSender())
+                FEELESS_ADDRESSES.isFeeless(_msgSender())
                     ? 0
                     : _takeFeeFrom({
                         projectId: projectId,

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -1575,7 +1575,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
                 JBFee({
                     amount: amount,
                     beneficiary: beneficiary,
-                    unlockTimestamp: block.timestamp + _FEE_BENEFICIARY_PROJECT_ID
+                    unlockTimestamp: block.timestamp + _FEE_HOLDING_SECONDS
                 })
             );
 

--- a/src/interfaces/IJBFeelessAddresses.sol
+++ b/src/interfaces/IJBFeelessAddresses.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IJBFeelessAddresses {
+    event SetFeelessAddress(address indexed account, bool indexed isFeeless, address caller);
+
+    function isFeelessAddress(address account) external view returns (bool);
+
+    function setFeelessAddress(address account, bool flag) external;
+}

--- a/src/interfaces/IJBFeelessAddresses.sol
+++ b/src/interfaces/IJBFeelessAddresses.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 interface IJBFeelessAddresses {
     event SetFeelessAddress(address indexed account, bool indexed isFeeless, address caller);
 
-    function isFeelessAddress(address account) external view returns (bool);
+    function isFeeless(address account) external view returns (bool);
 
     function setFeelessAddress(address account, bool flag) external;
 }

--- a/src/interfaces/terminal/IJBFeeTerminal.sol
+++ b/src/interfaces/terminal/IJBFeeTerminal.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {IJBTerminal} from "./IJBTerminal.sol";
+import {IJBFeelessAddresses} from "./../IJBFeelessAddresses.sol";
 import {JBFee} from "../../structs/JBFee.sol";
 
 /// @notice A terminal that can process and hold fees.
@@ -24,15 +25,14 @@ interface IJBFeeTerminal is IJBTerminal {
         address caller
     );
 
-    event UnlockHeldFees(
+    event ReturnHeldFees(
         uint256 indexed projectId,
         address indexed token,
         uint256 indexed amount,
-        uint256 unlockedFees,
+        uint256 returnedFees,
         uint256 leftoverAmount,
         address caller
     );
-    event SetFeelessAddress(address indexed account, bool indexed isFeeless, address caller);
 
     event FeeReverted(
         uint256 indexed projectId,
@@ -45,11 +45,9 @@ interface IJBFeeTerminal is IJBTerminal {
 
     function FEE() external view returns (uint256);
 
+    function FEELESS_ADDRESSES() external view returns (IJBFeelessAddresses);
+
     function heldFeesOf(uint256 projectId, address token) external view returns (JBFee[] memory);
 
-    function isFeelessAddress(address account) external view returns (bool);
-
     function processHeldFees(uint256 projectId, address token) external;
-
-    function setFeelessAddress(address account, bool flag) external;
 }

--- a/src/interfaces/terminal/IJBTerminal.sol
+++ b/src/interfaces/terminal/IJBTerminal.sol
@@ -74,7 +74,7 @@ interface IJBTerminal is IERC165 {
         uint256 projectId,
         address token,
         uint256 amount,
-        bool shouldUnlockHeldFees,
+        bool shouldReturnHeldFees,
         string calldata memo,
         bytes calldata metadata
     )

--- a/src/structs/JBFee.sol
+++ b/src/structs/JBFee.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.8.0;
 /// @custom:member amount The total amount the fee was taken from, as a fixed point number with the same number of
 /// decimals as the terminal in which this struct was created.
 /// @custom:member beneficiary The address that will receive the tokens that are minted as a result of the fee payment.
+/// @custom:member unlockTimestamp The timestamp at which the fee is unlocked and can be processed.
 struct JBFee {
     uint256 amount;
     address beneficiary;
+    uint256 unlockTimestamp;
 }

--- a/test/helpers/TestBaseWorkflow.sol
+++ b/test/helpers/TestBaseWorkflow.sol
@@ -11,6 +11,7 @@ import {ERC165, IERC165} from "@openzeppelin/contracts/utils/introspection/ERC16
 import {JBController} from "@juicebox/JBController.sol";
 import {JBDirectory} from "@juicebox/JBDirectory.sol";
 import {JBTerminalStore} from "@juicebox/JBTerminalStore.sol";
+import {JBFeelessAddresses} from "@juicebox/JBFeelessAddresses.sol";
 import {JBFundAccessLimits} from "@juicebox/JBFundAccessLimits.sol";
 import {JBRulesets} from "@juicebox/JBRulesets.sol";
 import {JBPermissions} from "@juicebox/JBPermissions.sol";
@@ -106,6 +107,7 @@ contract TestBaseWorkflow is Test, DeployPermit2 {
     JBTokens private _jbTokens;
     JBSplits private _jbSplits;
     JBController private _jbController;
+    JBFeelessAddresses private _jbFeelessAddresses;
     JBFundAccessLimits private _jbFundAccessLimits;
     JBTerminalStore private _jbTerminalStore;
     JBMultiTerminal private _jbMultiTerminal;
@@ -160,6 +162,10 @@ contract TestBaseWorkflow is Test, DeployPermit2 {
         return _jbController;
     }
 
+    function jbFeelessAddresses() internal view returns (JBFeelessAddresses) {
+        return _jbFeelessAddresses;
+    }
+
     function jbAccessConstraintStore() internal view returns (JBFundAccessLimits) {
         return _jbFundAccessLimits;
     }
@@ -194,6 +200,7 @@ contract TestBaseWorkflow is Test, DeployPermit2 {
         _jbRulesets = new JBRulesets(_jbDirectory);
         _jbSplits = new JBSplits(_jbDirectory);
         _jbFundAccessLimits = new JBFundAccessLimits(_jbDirectory);
+        _jbFeelessAddresses = new JBFeelessAddresses(_multisig);
 
         _usdcToken = new MockERC20("USDC", "USDC");
 
@@ -224,19 +231,20 @@ contract TestBaseWorkflow is Test, DeployPermit2 {
             _jbDirectory,
             _jbSplits,
             _jbTerminalStore,
+            _jbFeelessAddresses,
             IPermit2(_permit2),
-            _trustedForwarder,
-            _multisig
+            _trustedForwarder
         );
+
         _jbMultiTerminal2 = new JBMultiTerminal(
             _jbPermissions,
             _jbProjects,
             _jbDirectory,
             _jbSplits,
             _jbTerminalStore,
+            _jbFeelessAddresses,
             IPermit2(_permit2),
-            _trustedForwarder,
-            _multisig
+            _trustedForwarder
         );
 
         vm.label(_multisig, "projectOwner");
@@ -248,6 +256,7 @@ contract TestBaseWorkflow is Test, DeployPermit2 {
         vm.label(address(_usdcToken), "ERC20");
         vm.label(address(_jbPermissions), "JBPermissions");
         vm.label(address(_jbTokens), "JBTokens");
+        vm.label(address(_jbFeelessAddresses), "JBFeelessAddresses");
         vm.label(address(_jbFundAccessLimits), "JBFundAccessLimits");
         vm.label(address(_jbSplits), "JBSplits");
         vm.label(address(_jbController), "JBController");


### PR DESCRIPTION
thing 1, held fees.
- "unlock held fees" now named "return held fees"
- held fees no longer processable only by project owner or contract owner.
- held fee unlocked and processable after 28 days, by anyone.

thing 2, feeless addresses.
- feeless addresses moved into its own contract, allowing for terminal migrations without resetting feeless addresses.
- JBMultiTerminal is no longer Ownable.