### PR TITLE
fix: id parsing

### DIFF
--- a/src/libraries/JBMetadataResolver.sol
+++ b/src/libraries/JBMetadataResolver.sol
@@ -106,7 +106,7 @@ library JBMetadataResolver {
         internal
         pure
         returns (bytes memory newMetadata)
-    {   
+    {
         // Empty original metadata and maybe something in the first 32 bytes: create new metadata
         if (originalMetadata.length <= RESERVED_SIZE) {
             return abi.encodePacked(bytes32(originalMetadata), bytes32(abi.encodePacked(idToAdd, uint8(2))), dataToAdd);

--- a/test/TestMetadataParserLib.sol
+++ b/test/TestMetadataParserLib.sol
@@ -286,6 +286,37 @@ contract JBDelegateMetadataLib_Test is Test {
     }
 
     /**
+     * @notice Test adding `bytes32` and `uint` to a metadata which contains something in the first bytes32
+     */
+    function test_addToMetadata_preexistingMetadata(uint256 _reserved) external {
+        bytes memory _metadata = abi.encode(_reserved);
+
+        bytes memory _modifiedMetadata = parser.addDataToMetadata(
+            _metadata, bytes4(uint32(type(uint32).max)), abi.encode(uint32(69), bytes32(uint256(type(uint256).max)))
+        );
+
+        (bool _found, bytes memory _dataParsed) = parser.getDataFor(bytes4(uint32(type(uint32).max)), _modifiedMetadata);
+        (uint32 _a, bytes32 _b) = abi.decode(_dataParsed, (uint32, bytes32));
+
+        assertTrue(_found);
+        assertEq(_a, uint32(69));
+        assertEq(_b, bytes32(uint256(type(uint256).max)));
+
+        assertEq(uint256(bytes32(_modifiedMetadata)), _reserved);
+    }
+
+    function test_addToMetadata_invalidExistingTable_reverts() public {
+        vm.expectRevert(abi.encodeWithSignature("METADATA_TOO_SHORT()"));
+
+        // Preexisting metadata: 32B + 4B
+        parser.addDataToMetadata(
+            abi.encodePacked(bytes32(uint256(type(uint256).max)), bytes4(uint32(type(uint32).max))),
+            bytes4(uint32(type(uint32).max)),
+            bytes("12345678901234567890123456789012345678901234567890123456789012345678901234567890")
+        );
+    }
+
+    /**
      * @notice Test behaviour if the ID is not found in the lookup table.
      */
     function test_idNotFound(uint256 _numberOfIds) public {
@@ -350,4 +381,5 @@ contract JBDelegateMetadataLib_Test is Test {
         vm.expectRevert(abi.encodeWithSignature("LENGTH_MISMATCH()"));
         parser.createMetadata(_ids, _datas);
     }
+
 }

--- a/test/TestMetadataParserLib.sol
+++ b/test/TestMetadataParserLib.sol
@@ -381,5 +381,4 @@ contract JBDelegateMetadataLib_Test is Test {
         vm.expectRevert(abi.encodeWithSignature("LENGTH_MISMATCH()"));
         parser.createMetadata(_ids, _datas);
     }
-
 }

--- a/test/TestMetadataParserLib.sol
+++ b/test/TestMetadataParserLib.sol
@@ -268,6 +268,24 @@ contract JBDelegateMetadataLib_Test is Test {
     }
 
     /**
+     * @notice Test adding `bytes32` and `uint` to an empty metadata.
+     */
+    function test_addToMetadata_emptyInitialMetadata() external {
+        bytes memory _metadata;
+
+        bytes memory _modifiedMetadata = parser.addDataToMetadata(
+            _metadata, bytes4(uint32(type(uint32).max)), abi.encode(uint32(69), bytes32(uint256(type(uint256).max)))
+        );
+
+        (bool _found, bytes memory _dataParsed) = parser.getDataFor(bytes4(uint32(type(uint32).max)), _modifiedMetadata);
+        (uint32 _a, bytes32 _b) = abi.decode(_dataParsed, (uint32, bytes32));
+
+        assertTrue(_found);
+        assertEq(_a, uint32(69));
+        assertEq(_b, bytes32(uint256(type(uint256).max)));
+    }
+
+    /**
      * @notice Test behaviour if the ID is not found in the lookup table.
      */
     function test_idNotFound(uint256 _numberOfIds) public {

--- a/test/helpers/MetadataResolverHelper.sol
+++ b/test/helpers/MetadataResolverHelper.sol
@@ -75,46 +75,7 @@ contract MetadataResolverHelper {
         pure
         returns (bytes memory metadata)
     {
-        if (_ids.length != _datas.length) revert LENGTH_MISMATCH();
-
-        // Add a first empty 32B for the protocol reserved word
-        metadata = abi.encodePacked(bytes32(0));
-
-        // First offset for the data is after the first reserved word...
-        uint256 _offset = 1;
-
-        // ... and after the id/offset lookup table, rounding up to 32 bytes words if not a multiple
-        _offset += ((_ids.length * JBMetadataResolver.TOTAL_ID_SIZE) - 1) / JBMetadataResolver.WORD_SIZE + 1;
-
-        // For each id, add it to the lookup table with the next free offset, then increment the offset by the data
-        // length (rounded up)
-        for (uint256 _i; _i < _ids.length; ++_i) {
-            metadata = abi.encodePacked(metadata, _ids[_i], bytes1(uint8(_offset)));
-            _offset += _datas[_i].length / JBMetadataResolver.WORD_SIZE;
-
-            // Overflowing a bytes1?
-            if (_offset > 2 ** 8) revert METADATA_TOO_LONG();
-        }
-
-        // Pad the table to a multiple of 32B
-        uint256 _paddedLength = metadata.length % JBMetadataResolver.WORD_SIZE == 0
-            ? metadata.length
-            : (metadata.length / JBMetadataResolver.WORD_SIZE + 1) * JBMetadataResolver.WORD_SIZE;
-        assembly {
-            mstore(metadata, _paddedLength)
-        }
-
-        // Add each metadata to the array, each padded to 32 bytes
-        for (uint256 _i; _i < _datas.length; _i++) {
-            metadata = abi.encodePacked(metadata, _datas[_i]);
-            _paddedLength = metadata.length % JBMetadataResolver.WORD_SIZE == 0
-                ? metadata.length
-                : (metadata.length / JBMetadataResolver.WORD_SIZE + 1) * JBMetadataResolver.WORD_SIZE;
-
-            assembly {
-                mstore(metadata, _paddedLength)
-            }
-        }
+        return JBMetadataResolver.createMetadata(_ids, _datas);
     }
 
     /**


### PR DESCRIPTION
# Description

- Add create metadata in the lib
- Work on memory bytes (allowing all functions to be internal/inlined)
- Optimize slicing and small other memory management in Yul

Gas report:
| Test Name | Initial | ID Parsing Inlined/Yul | Slicing Optimised/Yul | Create Metadata as Internal Fn |
|-----------|---------|------------------------|----------------------|--------------------------------|
| `test_addToMetadata_bytes()` | `gas: 227694` | `gas: 218535` | `gas: 56728` | `gas: 57701` |
| `test_addToMetadata_mixed(uint256)` | `μ: 5969204, ~: 4138597` | `μ: 2786181, ~: 2206043` | `μ: 2386391, ~: 2084217` | `μ: 2272245, ~: 1731963` |
| `test_addToMetadata_uint(uint256)` | `μ: 22518840, ~: 14168844` | `μ: 10550888, ~: 7391244` | `μ: 10062127, ~: 6352367` | `μ: 10344009, ~: 6775516` |
| `test_createAndParse_bytes()` | `gas: 595006` | `gas: 511050` | `gas: 187596` | `gas: 190400` |
| `test_createAndParse_mixed(uint256)` | `μ: 258103, ~: 256175` | `μ: 186615, ~: 187497` | `μ: 115912, ~: 107514` | `μ: 112908, ~: 115450` |
| `test_createAndParse_uint(uint256)` | `μ: 24200244, ~: 16913595` | `μ: 9686668, ~: 6362206` | `μ: 9359069, ~: 6594664` | `μ: 9989432, ~: 6384670` |
| `test_createRevertIfOffsetTooBig(uint256)` | `μ: 988573, ~: 943927` | `μ: 1015916, ~: 1019213` | `μ: 981730, ~: 946397` | `μ: 1240683, ~: 1233713` |
| `test_differentSizeIdAndMetadataArray_reverts(uint256,uint256)` | `μ: 67125, ~: 66197` | `μ: 67385, ~: 65456` | `μ: 69654, ~: 71674` | `μ: 90785, ~: 85841` |
| `test_emptyMetadata(uint256)` | `μ: 11787, ~: 11906` | `μ: 11760, ~: 11906` | `μ: 11755, ~: 11906` | `μ: 11779, ~: 11906` |
| `test_idNotFound(uint256)` | `μ: 471724, ~: 389854` | `μ: 407676, ~: 298977` | `μ: 395712, ~: 274954` | `μ: 439112, ~: 331395` |
| `test_parse()` | `gas: 52063` | `gas: 47484` | `gas: 26015` | `gas: 26015` |

New functionnality:
test_addToMetadata_emptyInitialMetadata() (gas: 16202)

## Limitations & risks

Introducing new (Yul) bug

# Check-list
- [x] Tests are covering the new feature
- [x] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [x] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [x] I have run the test locally (and they pass)
- [x] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:
Every contract using the metadata library

- Indirectly:
NA