### PR TITLE
ruleset paging

### DIFF
--- a/src/JBController.sol
+++ b/src/JBController.sol
@@ -137,34 +137,40 @@ contract JBController is JBPermissioned, ERC2771Context, ERC165, IJBController, 
         metadata = ruleset.expandMetadata();
     }
 
-    /// @notice Get all the currently queued rulesets for a project, including their metadata.
-    /// @param projectId The ID of the project to get the queued rulesets of.
-    /// @return queuedRulesets The queued rulesets as an array of `JBRulesetWithMetadata` structs.
-    function queuedRulesetsOf(uint256 projectId)
+    /// @notice Get a page of rulesets for a project in order of latest to earliest.
+    /// @param projectId The ID of the project to get the rulesets of.
+    /// @param startingId The ID of the ruleset to begin with. If 0 is passed, the latest ruleset will be used.
+    /// @param size The number of rulesets to return.
+    /// @return rulesets The rulesets as an array of `JBRuleset` structs.
+    function rulesetsOf(
+        uint256 projectId,
+        uint256 startingId,
+        uint256 size
+    )
         external
         view
         override
-        returns (JBRulesetWithMetadata[] memory queuedRulesets)
+        returns (JBRulesetWithMetadata[] memory rulesets)
     {
-        // Get the queued rulesets.
-        JBRuleset[] memory rulesets = RULESETS.queuedRulesetsOf(projectId);
+        // Get the rulesets.
+        JBRuleset[] memory baseRulesets = RULESETS.rulesetsOf(projectId, startingId, size);
 
         // Keep a reference to the number of rulesets.
-        uint256 numberOfRulesets = rulesets.length;
+        uint256 numberOfRulesets = baseRulesets.length;
 
         // Initialize the array being returned.
-        queuedRulesets = new JBRulesetWithMetadata[](numberOfRulesets);
+        rulesets = new JBRulesetWithMetadata[](numberOfRulesets);
 
         // Keep a reference to the ruleset being iterated on.
-        JBRuleset memory ruleset;
+        JBRuleset memory baseRuleset;
 
         // Populate the array with the rulesets and their metadata.
         for (uint256 i; i < numberOfRulesets; i++) {
             // Set the ruleset being iterated on.
-            ruleset = rulesets[i];
+            baseRuleset = baseRulesets[i];
 
             // Set the returned value.
-            queuedRulesets[i] = JBRulesetWithMetadata({ruleset: ruleset, metadata: ruleset.expandMetadata()});
+            rulesets[i] = JBRulesetWithMetadata({ruleset: baseRuleset, metadata: baseRuleset.expandMetadata()});
         }
     }
 

--- a/src/interfaces/IJBController.sol
+++ b/src/interfaces/IJBController.sol
@@ -97,10 +97,14 @@ interface IJBController is IERC165, IJBProjectMetadataRegistry, IJBDirectoryAcce
         view
         returns (JBRuleset memory, JBRulesetMetadata memory metadata, JBApprovalStatus);
 
-    function queuedRulesetsOf(uint256 projectId)
+    function rulesetsOf(
+        uint256 projectId,
+        uint256 startingId,
+        uint256 size
+    )
         external
         view
-        returns (JBRulesetWithMetadata[] memory queuedRulesets);
+        returns (JBRulesetWithMetadata[] memory rulesets);
 
     function currentRulesetOf(uint256 projectId)
         external

--- a/src/interfaces/IJBRulesets.sol
+++ b/src/interfaces/IJBRulesets.sol
@@ -30,7 +30,14 @@ interface IJBRulesets is IJBControlled {
         view
         returns (JBRuleset memory ruleset, JBApprovalStatus approvalStatus);
 
-    function queuedRulesetsOf(uint256 projectId) external view returns (JBRuleset[] memory queuedRulesets);
+    function rulesetsOf(
+        uint256 projectId,
+        uint256 startingId,
+        uint256 size
+    )
+        external
+        view
+        returns (JBRuleset[] memory rulesets);
 
     function upcomingRulesetOf(uint256 projectId) external view returns (JBRuleset memory ruleset);
 

--- a/test/TestRulesetQueueing.sol
+++ b/test/TestRulesetQueueing.sol
@@ -305,11 +305,11 @@ contract TestRulesetQueuing_Local is TestBaseWorkflow {
             upcomingRuleset = jbRulesets().upcomingRulesetOf(projectId);
 
             // Get a list of queued rulesets
-            JBRuleset[] memory queuedRulesetsOf = jbRulesets().queuedRulesetsOf(projectId);
+            JBRuleset[] memory rulesetsOf = jbRulesets().rulesetsOf(projectId, 0, 1);
 
             // Make sure the upcoming ruleset is the ruleset currently under the approval hook.
             assertEq(upcomingRuleset.weight, _config[0].weight);
-            assertEq(queuedRulesetsOf[0].weight, _config[0].weight);
+            assertEq(rulesetsOf[0].weight, _config[0].weight);
 
             // If the full deadline duration included in the ruleset.
             if (
@@ -533,9 +533,9 @@ contract TestRulesetQueuing_Local is TestBaseWorkflow {
         assertEq(_queued.weight, _weightFirstQueued);
 
         // Get a list of queued rulesets
-        JBRuleset[] memory queuedRulesets = jbRulesets().queuedRulesetsOf(projectId);
+        JBRuleset[] memory queuedRulesets = jbRulesets().rulesetsOf(projectId, 0, 1);
 
-        // Ensure queuedRulesetsOf is accurate
+        // Ensure rulesetsOf is accurate
         assertEq(queuedRulesets[0].weight, _weightFirstQueued);
 
         // Package up another config.
@@ -563,9 +563,9 @@ contract TestRulesetQueuing_Local is TestBaseWorkflow {
         assertEq(_requeued.weight, _weightInitial);
 
         // Get a list of queued rulesets
-        JBRuleset[] memory queuedRulesets2 = jbRulesets().queuedRulesetsOf(projectId);
+        JBRuleset[] memory queuedRulesets2 = jbRulesets().rulesetsOf(projectId, 0, 1);
 
-        // Ensure queuedRulesetsOf is accurate
+        // Ensure rulesetsOf is accurate
         assertEq(queuedRulesets2[0].weight, _weightSecondQueued);
 
         // Warp to when the initial ruleset rolls over and again becomes the current.
@@ -584,9 +584,9 @@ contract TestRulesetQueuing_Local is TestBaseWorkflow {
         assertEq(_requeued2.weight, _weightSecondQueued);
 
         // Get queued rulesets
-        JBRuleset[] memory queuedRulesets3 = jbRulesets().queuedRulesetsOf(projectId);
+        JBRuleset[] memory queuedRulesets3 = jbRulesets().rulesetsOf(projectId, 0, 1);
 
-        // Ensure queuedRulesetsOf is accurate
+        // Ensure rulesetsOf is accurate
         assertEq(queuedRulesets3[0].weight, _weightSecondQueued);
     }
 
@@ -700,19 +700,22 @@ contract TestRulesetQueuing_Local is TestBaseWorkflow {
         uint256 id = launchProjectForTestWithThreeRulesets();
 
         // Get a list of queued rulesets
-        JBRuleset[] memory queuedRulesetsOf = jbRulesets().queuedRulesetsOf(id);
+        JBRuleset[] memory rulesetsOf = jbRulesets().rulesetsOf(id, 0, 3);
 
         // check: two queued
-        assertEq(queuedRulesetsOf.length, 2);
-
-        // check: queued with nearest start time
-        assertEq(queuedRulesetsOf[0].weight, _weight + 100);
+        assertEq(rulesetsOf.length, 3);
 
         // check: queued with furthest start time
-        assertEq(queuedRulesetsOf[1].weight, _weight + 200);
+        assertEq(rulesetsOf[0].weight, _weight + 200);
+
+        // check: queued with nearest start time
+        assertEq(rulesetsOf[1].weight, _weight + 100);
 
         // get the current ruleset
         JBRuleset memory currentRuleset = jbRulesets().currentOf(id);
+
+        // check: queued with nearest start time
+        assertEq(rulesetsOf[2].weight, currentRuleset.weight);
 
         // check: current should be the initial ruleset
         assertEq(currentRuleset.weight, _weight);

--- a/test/TestRulesetQueueing.sol
+++ b/test/TestRulesetQueueing.sol
@@ -695,14 +695,14 @@ contract TestRulesetQueuing_Local is TestBaseWorkflow {
         }
     }
 
-    function testRulesetQueueingViewAccuracy() public {
+    function testRulesetViewAccuracy() public {
         // setup: deploy project and queue 2 rulesets atop the initial ruleset
         uint256 id = launchProjectForTestWithThreeRulesets();
 
         // Get a list of queued rulesets
         JBRuleset[] memory rulesetsOf = jbRulesets().rulesetsOf(id, 0, 3);
 
-        // check: two queued
+        // check: three rulesets returned
         assertEq(rulesetsOf.length, 3);
 
         // check: queued with furthest start time
@@ -711,11 +711,11 @@ contract TestRulesetQueuing_Local is TestBaseWorkflow {
         // check: queued with nearest start time
         assertEq(rulesetsOf[1].weight, _weight + 100);
 
+        // check: current with nearest start time
+        assertEq(rulesetsOf[2].weight, _weight);
+
         // get the current ruleset
         JBRuleset memory currentRuleset = jbRulesets().currentOf(id);
-
-        // check: queued with nearest start time
-        assertEq(rulesetsOf[2].weight, currentRuleset.weight);
 
         // check: current should be the initial ruleset
         assertEq(currentRuleset.weight, _weight);
@@ -725,5 +725,68 @@ contract TestRulesetQueuing_Local is TestBaseWorkflow {
 
         // check: upcoming ruleset should be 2nd queued
         assertEq(upcomingRuleset.weight, _weight + 100);
+
+        // Get a list of queued rulesets
+        rulesetsOf = jbRulesets().rulesetsOf(id, 0, 3);
+
+        // check: three rulesets returned again
+        assertEq(rulesetsOf.length, 3);
+
+        // check: queued with furthest start time
+        assertEq(rulesetsOf[0].weight, _weight + 200);
+
+        // check: current with nearest start time
+        assertEq(rulesetsOf[1].weight, _weight + 100);
+
+        // check: past with nearest start time
+        assertEq(rulesetsOf[2].weight, _weight);
+
+        // Get a list of queued rulesets
+        rulesetsOf = jbRulesets().rulesetsOf(id, 0, 2);
+
+        // check: two rulesets returned again
+        assertEq(rulesetsOf.length, 2);
+
+        // check: queued with furthest start time
+        assertEq(rulesetsOf[0].weight, _weight + 200);
+
+        // check: current with nearest start time
+        assertEq(rulesetsOf[1].weight, _weight + 100);
+
+        // Get a list of queued rulesets
+        rulesetsOf = jbRulesets().rulesetsOf(id, upcomingRuleset.id, 2);
+
+        // check: two rulesets returned again
+        assertEq(rulesetsOf.length, 2);
+
+        // check: current with nearest start time
+        assertEq(rulesetsOf[0].weight, _weight + 100);
+
+        // check: past with nearest start time
+        assertEq(rulesetsOf[1].weight, _weight);
+
+        // Get a list of queued rulesets
+        rulesetsOf = jbRulesets().rulesetsOf(id, upcomingRuleset.id, 1);
+
+        // check: one rulesets returned again
+        assertEq(rulesetsOf.length, 1);
+
+        // check: current with nearest start time
+        assertEq(rulesetsOf[0].weight, _weight + 100);
+
+        // Get a list of queued rulesets with a larger size than there are rulesets.
+        rulesetsOf = jbRulesets().rulesetsOf(id, 0, 10);
+
+        // check: three rulesets returned
+        assertEq(rulesetsOf.length, 3);
+
+        // check: queued with furthest start time
+        assertEq(rulesetsOf[0].weight, _weight + 200);
+
+        // check: queued with nearest start time
+        assertEq(rulesetsOf[1].weight, _weight + 100);
+
+        // check: current with nearest start time
+        assertEq(rulesetsOf[2].weight, _weight);
     }
 }


### PR DESCRIPTION
# Description

Replace `queuedRulesetsOf`, which only returns rulesets in the future, with `rulesetsOf` which allows paging of a projects rulesets future and past. The first ruleset returned will be the one with the corresponding `startingId` (if 0 is passed the latest configured ruleset will be used), and each preceding ruleset will be included until the `size` limit is reached.

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: